### PR TITLE
Upping Laravel version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "5.2.*",
+        "laravel/framework": "5.2.* || 5.4.*",
         "ramsey/uuid": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
I've got a project going with Laravel 5.4 and have tested that the basic functionality still works.