### PR TITLE
Adding Query Scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ composer require jamesmills/eloquent-uuid
 
 In order to use this trait, your **schema** must be something like:
 
-```
+```php
 <?php
 	// ...
 	Schema::create('users', function (Blueprint $table) {
@@ -29,7 +29,7 @@ In order to use this trait, your **schema** must be something like:
 
 In order to use this in your models, just put `use HasUuidTrait;`:
 
-```
+```php
 <?php
 
 namespace App;
@@ -39,4 +39,47 @@ class User extends Eloquent
 {
 	use HasUuidTrait;
 }
+```
+
+#### Querying your models
+
+You may use the `findByUuidOrFail` method to try and fetch a model directly:
+
+```php
+<?php
+
+Route::get('/user/{uuid}', function($uuid) {
+    try {
+        return App\User::findByUuidOrFail($uuid);
+    } catch (Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+        abort(404);
+    }
+});
+```
+
+You may also use the `withUuid` and `withUuids` local query scopes with the query builder.
+
+```php
+<?php
+
+Route::get('/user/{uuid}', function($uuid) {
+    $user = App\User::withUuid($uuid)->first();
+    if (! $user) {
+        // Do something else...
+    }
+});
+```
+```php
+<?php
+
+Route::delete('/users', function(Request $request) {
+    // Receive an array of UUIDs
+    $uuids = $request->input('uuids');
+
+    // Try to get the Users
+    $users = App\User::withUuids($uuids)->all();
+    
+    // Handle the delete and return
+    $users->delete();
+});
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "5.2.*",
+        "laravel/framework": "5.2.* || 5.4.*",
         "ramsey/uuid": "^3.2"
     },
     "autoload": {

--- a/src/HasUuidTrait.php
+++ b/src/HasUuidTrait.php
@@ -24,4 +24,28 @@ trait HasUuidTrait
     {
         return self::whereUuid($uuid)->firstOrFail();
     }
+
+    /**
+     * Eloquent scope to look for a given UUID
+     * 
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  String                                $uuid  The UUID to search for
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithUuid($query, $uuid)
+    {
+        return $query->where('uuid', $uuid);
+    }
+
+    /**
+     * Eloquent scope to look for multiple given UUIDs
+     * 
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  Array                                 $uuids  The UUIDs to search for
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithUuids($query, Array $uuids)
+    {
+        return $query->whereIn('uuid', $uuids);
+    }
 }


### PR DESCRIPTION
This adds 2 local scopes to save having to add `where('uuid', $uuid)`. The scopes are `withUuid` and `withUuids`.

For example, this would allow you to use: `FooModel::withUuid($my_uuid)->find();`.

Sorry, I think this includes the Laravel version update from the other PR. I can rollback if needs be.